### PR TITLE
parse and render nested comments

### DIFF
--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -15,14 +15,24 @@ export function MarkdownPreview({ markdown }: MarkdownPreviewProps) {
     setTimeout(() => setCopied(false), 2000);
   };
 
+  const decodeHTMLEntities = (text: string): string => {
+    const textarea = document.createElement('textarea');
+    textarea.innerHTML = text;
+    return textarea.value;
+  };
+
   // Basic markdown rendering (you might want to use a proper markdown library for production)
   const renderMarkdown = (text: string) => {
-    return text.split('\n').map((line, i) => {
+    return text.split('\n').map((origLine, i) => {
+      const line = decodeHTMLEntities(origLine);
       if (line.startsWith('# ')) {
         return <h1 key={i} className="text-2xl font-bold mb-4">{line.slice(2)}</h1>;
       }
       if (line.startsWith('## ')) {
         return <h2 key={i} className="text-xl font-bold mb-3">{line.slice(3)}</h2>;
+      }
+      if (line.startsWith('**') && line.endsWith('**')) {
+        return <strong key={i} className="block mb-2">{line.slice(2, -2)}</strong>;
       }
       if (line.startsWith('*') && line.endsWith('*')) {
         return <em key={i} className="block mb-2">{line.slice(1, -1)}</em>;
@@ -30,8 +40,29 @@ export function MarkdownPreview({ markdown }: MarkdownPreviewProps) {
       if (line === '---') {
         return <hr key={i} className="my-4" />;
       }
-      if (line.startsWith('**') && line.endsWith('**')) {
-        return <strong key={i} className="block mb-2">{line.slice(2, -2)}</strong>;
+      if (line.trim().startsWith('>')) {
+        const match = line.match(/^((?:>\s?)+)\s*(.*)$/);
+        if (match) {
+          const markers = match[1].match(/>/g) || [];
+          const level = markers.length;
+          const content = match[2];
+          const trimmedContent = content.trim();
+          const inlineContent =
+            /^\*\*u\/.+\*\*$/.test(trimmedContent) ? (
+              <strong>{trimmedContent.slice(2, -2)}</strong>
+            ) : (
+              <p>{content}</p>
+            );
+          let nestedContent: JSX.Element = inlineContent;
+          for (let j = 0; j < level; j++) {
+            nestedContent = (
+              <blockquote key={`${i}-${j}`} className="border-l-4 border-gray-300 pl-2 mb-0">
+                {nestedContent}
+              </blockquote>
+            );
+          }
+          return nestedContent;
+        }
       }
       return line ? <p key={i} className="mb-2">{line}</p> : <br key={i} />;
     });

--- a/src/components/RedditForm.tsx
+++ b/src/components/RedditForm.tsx
@@ -9,6 +9,30 @@ export function RedditForm({ onSubmit }: RedditFormProps) {
   const [url, setUrl] = useState('');
   const [loading, setLoading] = useState(false);
 
+  // Recursive function to process a single comment and its children.
+  const processComment = (comment: any, depth = 0): string => {
+    const indent = "> ".repeat(depth);
+    let mdComment = `${indent}**u/${comment.data.author}**\n`;
+
+    // Split the comment body into lines and add indent for each line.
+    const commentBody = comment.data.body
+      .split('\n')
+      .map((line: string) => `${indent}${line}`)
+      .join('\n');
+    mdComment += `${commentBody}\n\n`;
+
+    // Check if the comment has any replies
+    if (comment.data.replies && comment.data.replies.data && comment.data.replies.data.children) {
+      comment.data.replies.data.children.forEach((child: any) => {
+        if (child.kind === 't1') {
+          mdComment += processComment(child, depth + 1);
+        }
+      });
+    }
+    
+    return mdComment;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
@@ -26,7 +50,8 @@ export function RedditForm({ onSubmit }: RedditFormProps) {
       const comments = data[1].data.children;
       comments.forEach((comment: any) => {
         if (comment.kind === 't1') {
-          md += `**u/${comment.data.author}**\n\n${comment.data.body}\n\n`;
+          // Use the recursive processor for each top-level comment.
+          md += processComment(comment, 0);
         }
       });
       


### PR DESCRIPTION
This change adds support for nested comments.

It also fixes a few bugs I found along the way
 - moved processing of ** above * (usernames inside ** ** were only having one asterisk parsed)
 - decode html entities like &gt; to >